### PR TITLE
Missing data points

### DIFF
--- a/Opt_Moto.py
+++ b/Opt_Moto.py
@@ -518,7 +518,7 @@ class ULAIO01(UIExample):
             self.experiment_dateTime.text = str(self.input_dateTime.get())
 
             self.experiment_duration = tree.find("./metadata/experiment/duration")
-            self.experiment_duration.text = str(self.testtimebox.get())
+            self.experiment_duration.text = str(self.durationtime())
 
             self.experiment_description = tree.find("./metadata/experiment/description")
             self.experiment_description.text = str(self.input_ExperimentDescription.get())
@@ -537,10 +537,10 @@ class ULAIO01(UIExample):
                 print(et.tostring(period))
                 if i % 2 == 0:
                     type = et.SubElement(period, "type")
-                    type.text = "OptomotoR"
+                    type.text = "OptomotorR"
                 else:
                     type = et.SubElement(period, "type")
-                    type.text = "OptomotoL"
+                    type.text = "OptomotorL"
                 duration = et.SubElement(period, "duration")
                 duration.text = str(self.periodbox.get())
                 outcome = et.SubElement(period, "outcome")
@@ -570,6 +570,11 @@ class ULAIO01(UIExample):
         while self.testtime % 31 != 0:  # the variable has to be divisible by 31 (COUNTINOUS mode restriction)
             self.testtime += 1
         return self.testtime
+
+    def duration_time(self):
+        self.durationtime =60 * int(self.testtimebox.get())  # Multiply the total duration with 60 to get seconds.
+        # Will be used later to fill the xml sheet.
+        return self.durationtime
 
     def give_curr_count(self):
         status, curr_count, curr_index = ul.get_status(

--- a/Opt_Moto.py
+++ b/Opt_Moto.py
@@ -518,7 +518,7 @@ class ULAIO01(UIExample):
             self.experiment_dateTime.text = str(self.input_dateTime.get())
 
             self.experiment_duration = tree.find("./metadata/experiment/duration")
-            self.experiment_duration.text = str(self.durationtime())
+            self.experiment_duration.text = str(self.testtimebox.get())
 
             self.experiment_description = tree.find("./metadata/experiment/description")
             self.experiment_description.text = str(self.input_ExperimentDescription.get())
@@ -537,10 +537,10 @@ class ULAIO01(UIExample):
                 print(et.tostring(period))
                 if i % 2 == 0:
                     type = et.SubElement(period, "type")
-                    type.text = "OptomotorR"
+                    type.text = "OptomotoR"
                 else:
                     type = et.SubElement(period, "type")
-                    type.text = "OptomotorL"
+                    type.text = "OptomotoL"
                 duration = et.SubElement(period, "duration")
                 duration.text = str(self.periodbox.get())
                 outcome = et.SubElement(period, "outcome")
@@ -570,11 +570,6 @@ class ULAIO01(UIExample):
         while self.testtime % 31 != 0:  # the variable has to be divisible by 31 (COUNTINOUS mode restriction)
             self.testtime += 1
         return self.testtime
-
-    def duration_time(self):
-        self.durationtime =60 * int(self.testtimebox.get())  # Multiply the total duration with 60 to get seconds.
-        # Will be used later to fill the xml sheet.
-        return self.durationtime
 
     def give_curr_count(self):
         status, curr_count, curr_index = ul.get_status(

--- a/Opt_Moto.py
+++ b/Opt_Moto.py
@@ -132,7 +132,7 @@ class ULAIO01(UIExample):
         self.textfile = open("Rawtext.txt", "a+")  # textfile that the data will be written to
 
         # Function for the writing of the complete buffer to a text file and stopping the process
-        if curr_count >= self.test_time() - 100:
+        if curr_count >= self.test_time() - 30: # This marks the end of the experiment.
             self.full_file()
 
         # Call this method again until the stop_input button is pressed
@@ -518,7 +518,7 @@ class ULAIO01(UIExample):
             self.experiment_dateTime.text = str(self.input_dateTime.get())
 
             self.experiment_duration = tree.find("./metadata/experiment/duration")
-            self.experiment_duration.text = str(self.testtimebox.get())
+            self.experiment_duration.text = str(self.durationtime())
 
             self.experiment_description = tree.find("./metadata/experiment/description")
             self.experiment_description.text = str(self.input_ExperimentDescription.get())
@@ -540,7 +540,7 @@ class ULAIO01(UIExample):
                     type.text = "OptomotoR"
                 else:
                     type = et.SubElement(period, "type")
-                    type.text = "OptomotoL"
+                    type.text = "OptomotorL"
                 duration = et.SubElement(period, "duration")
                 duration.text = str(self.periodbox.get())
                 outcome = et.SubElement(period, "outcome")
@@ -570,6 +570,11 @@ class ULAIO01(UIExample):
         while self.testtime % 31 != 0:  # the variable has to be divisible by 31 (COUNTINOUS mode restriction)
             self.testtime += 1
         return self.testtime
+
+    def duration_time(self):
+        self.durationtime =60 * int(self.testtimebox.get())  # Multiply the total duration with 60 to get seconds.
+        # This data is later on added to the xml file
+        return self.durationtime
 
     def give_curr_count(self):
         status, curr_count, curr_index = ul.get_status(

--- a/Optomotorics_blueprint.xml
+++ b/Optomotorics_blueprint.xml
@@ -22,7 +22,7 @@
 		<duration></duration>
 		<description></description>
 		<sample_rate></sample_rate>
-		<arena_type>motor</arena_type>
+		<arena_type>Joystick</arena_type>
 		<meter_type></meter_type>
 	</experiment>
 </metadata>
@@ -36,12 +36,12 @@
 	</CSV_descriptor>
 	<variables>
 		<variable number="1">
-		    <type>fly</type>		
+		    <type>j_pos</type>		
 			<var_type>float32</var_type>
 			<unit>arb_unit</unit>
 		</variable>	
 		<variable number="2">
-		    <type>arena</type>		
+		    <type>a_pos</type>		
 			<var_type>float32</var_type>
 			<unit>arb_unit</unit>
 		</variable>

--- a/Optomotorics_blueprint.xml
+++ b/Optomotorics_blueprint.xml
@@ -22,7 +22,7 @@
 		<duration></duration>
 		<description></description>
 		<sample_rate></sample_rate>
-		<arena_type>Joystick</arena_type>
+		<arena_type>motor</arena_type>
 		<meter_type></meter_type>
 	</experiment>
 </metadata>
@@ -36,12 +36,12 @@
 	</CSV_descriptor>
 	<variables>
 		<variable number="1">
-		    <type>j_pos</type>		
+		    <type>fly</type>		
 			<var_type>float32</var_type>
 			<unit>arb_unit</unit>
 		</variable>	
 		<variable number="2">
-		    <type>a_pos</type>		
+		    <type>arena</type>		
 			<var_type>float32</var_type>
 			<unit>arb_unit</unit>
 		</variable>


### PR DESCRIPTION
I found the command that stops the data acquisition. While it might seem obvious now it was not so easy to actually find it. To explain it: The total number of data points for the experiment is calculated (test_time) and compares this to the currently total number of generated data points (curr_count). This acts as a timer. Whenever curr_count is equal to or greater than test_time it stops the operation. To prevent overshooting a number of data points 100 were subtracted from the test_time. 100 seems to be randomly picked. But, setting it to 0 adds another 20 data points, whereas 30 seems to be pretty accurate. 
I still do not know where curr_count is generated, from what I can see it is only called and not actually created. It might be from a separate python script.
Anyway, the result from changing 100 to 30 creates a lot more accurate number of data on the last period. From having roughly 40±5 missing data points it is now 0±2.